### PR TITLE
feat: add example text selection

### DIFF
--- a/components/features/StyleTransformer.tsx
+++ b/components/features/StyleTransformer.tsx
@@ -324,7 +324,7 @@ export function StyleTransformer() {
               display: "flex",
               flexDirection: "column",
               borderRight: `1px solid ${C.rule}`,
-              overflow: "hidden",
+              overflowY: "auto",
             }}
           >
             <div
@@ -352,7 +352,7 @@ export function StyleTransformer() {
               </span>
             </div>
 
-            <div style={{ flex: 1, position: "relative", overflow: "hidden" }}>
+            <div style={{ flex: 1, minHeight: "140px", position: "relative", overflow: "hidden" }}>
               <textarea
                 id="input"
                 value={inputText}


### PR DESCRIPTION
## Summary

- 入力エリア下に例文リストを追加
- クリックで入力欄に流し込み
- `EXAMPLES` 配列をファイル上部に集約、手動編集しやすい構成
- テキストエリアに `minHeight` を設定し、例文・ボタンに押し潰されないよう修正

## Test plan

- [ ] `bun dev` でローカル起動確認
- [ ] 例文クリック → 入力欄に反映されることを確認
- [ ] スタイルボタンで変換できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)